### PR TITLE
Initial Processors

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -1,5 +1,6 @@
 dependencies {
   api("org.checkerframework:checker-qual:3.12.0")
+  api("net.kyori:coffee:1.0.0-SNAPSHOT")
   api("space.vectrix.flare:flare:0.1.0")
 }
 

--- a/api/src/main/java/space/vectrix/inertia/Universe.java
+++ b/api/src/main/java/space/vectrix/inertia/Universe.java
@@ -263,7 +263,7 @@ public interface Universe<H extends Holder<C>, C> {
    * @return The component types registry
    * @since 0.1.0
    */
-  @NonNull ComponentTypes componentTypes();
+  @NonNull ComponentTypes types();
 
   /**
    * The universe builder.

--- a/api/src/main/java/space/vectrix/inertia/Universe.java
+++ b/api/src/main/java/space/vectrix/inertia/Universe.java
@@ -34,9 +34,13 @@ import space.vectrix.inertia.holder.HolderResolver;
 import space.vectrix.inertia.holder.Holders;
 import space.vectrix.inertia.injector.InjectionMethod;
 import space.vectrix.inertia.injector.InjectionStructure;
+import space.vectrix.inertia.processor.Processing;
+import space.vectrix.inertia.processor.Processor;
+import space.vectrix.inertia.processor.Processors;
 
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.function.Function;
 
 /**
  * The universe of {@code H} holders and {@code C} components.
@@ -53,6 +57,28 @@ public interface Universe<H extends Holder<C>, C> {
    * @since 0.1.0
    */
   @NonNull String id();
+
+  /**
+   * Ticks this universe by running the processors in order
+   * of the priority they provide and returns the tick count
+   * {@code int}.
+   *
+   * @return The tick count
+   * @since 0.1.0
+   */
+  int tick();
+
+  /**
+   * Creates a new processor using the specified {@link Class} type
+   * and {@link Function}.
+   *
+   * @param type The processor class
+   * @param processorFunction The processor function
+   * @param <T> The specific processor type
+   * @return A completable future containing the processor
+   * @since 0.1.0
+   */
+  <T extends Processor<H, C>> @NonNull CompletableFuture<T> createProcessor(final @NonNull Class<T> type, final @NonNull Function<Universe<H, C>, T> processorFunction);
 
   /**
    * Creates a new holder and returns an {@code int} index.
@@ -108,9 +134,19 @@ public interface Universe<H extends Holder<C>, C> {
   <T extends C> @NonNull CompletableFuture<T> createComponent(final @NonNull H holder, final @NonNull ComponentType componentType);
 
   /**
+   * Removes the processor with the specified {@link Class} type.
+   *
+   * @param processor The processor class
+   * @return True if the processor was removed, otherwise false
+   * @since 0.1.0
+   */
+  boolean removeProcessor(final @NonNull Class<? extends Processor<H, C>> processor);
+
+  /**
    * Removes the holder with the specified {@code int} index.
    *
    * @param index The holder index
+   * @return True if the holder was removed, otherwise false
    * @since 0.1.0
    */
   boolean removeHolder(final int index);
@@ -119,6 +155,7 @@ public interface Universe<H extends Holder<C>, C> {
    * Removes the specified {@code T} holder.
    *
    * @param holder The holder
+   * @return True if the holder was removed, otherwise false
    * @since 0.1.0
    */
   boolean removeHolder(final @NonNull H holder);
@@ -197,9 +234,17 @@ public interface Universe<H extends Holder<C>, C> {
   <T extends C> @NonNull Optional<T> getComponent(final @NonNull H holder, final @NonNull ComponentType componentType);
 
   /**
+   * Returns the {@link Processors}.
+   *
+   * @return The processor registry
+   * @since 0.1.0
+   */
+  @NonNull Processors<H, C> processors();
+
+  /**
    * Returns the {@link Holders}.
    *
-   * @return The holders registry
+   * @return The holder registry
    * @since 0.1.0
    */
   @NonNull Holders<H, C> holders();
@@ -207,7 +252,7 @@ public interface Universe<H extends Holder<C>, C> {
   /**
    * Returns the {@link Components}.
    *
-   * @return The components registry
+   * @return The component registry
    * @since 0.1.0
    */
   @NonNull Components<H, C> components();
@@ -238,6 +283,16 @@ public interface Universe<H extends Holder<C>, C> {
     @NonNull Builder<H, C> id(final @NonNull String id);
 
     /**
+     * Returns this {@link Builder} with the specified {@link Processing.Factory}
+     * processing system.
+     *
+     * @param processing The processing system
+     * @return This builder
+     * @since 0.1.0
+     */
+    @NonNull Builder<H, C> processing(final Processing.@NonNull Factory processing);
+
+    /**
      * Returns this {@link Builder} with the specified {@link HolderResolver.Factory}
      * holder resolver.
      *
@@ -256,6 +311,15 @@ public interface Universe<H extends Holder<C>, C> {
      * @since 0.1.0
      */
     @NonNull Builder<H, C> componentResolver(final ComponentResolver.@NonNull Factory resolver);
+
+    /**
+     * Returns this {@link Builder} with the specified {@link Processors} registry.
+     *
+     * @param registry The processor registry
+     * @return This builder
+     * @since 0.1.0
+     */
+    @NonNull Builder<H, C> processorRegistry(final @NonNull Processors<H, C> registry);
 
     /**
      * Returns this {@link Builder} with the specified {@link Holders} registry.

--- a/api/src/main/java/space/vectrix/inertia/component/ComponentResolver.java
+++ b/api/src/main/java/space/vectrix/inertia/component/ComponentResolver.java
@@ -49,10 +49,10 @@ public interface ComponentResolver<H extends Holder<C>, C> {
    * @return The component type
    * @since 0.1.0
    */
-  @NonNull ComponentType resolve(final @NonNull Class<?> type,
-                                 final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
-                                 final InjectionMethod.@NonNull Factory<?, C> componentInjector,
-                                 final InjectionMethod.@NonNull Factory<?, H> holderInjector);
+  <T extends C> @NonNull ComponentType resolve(final @NonNull Class<T> type,
+                                               final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
+                                               final InjectionMethod.@NonNull Factory<?, C> componentInjector,
+                                               final InjectionMethod.@NonNull Factory<?, H> holderInjector);
 
   /**
    * Creates the {@code T} component for the specified {@code int} holder

--- a/api/src/main/java/space/vectrix/inertia/component/Components.java
+++ b/api/src/main/java/space/vectrix/inertia/component/Components.java
@@ -37,7 +37,7 @@ import java.util.Optional;
  * @param <C> The component type
  * @since 0.1.0
  */
-public interface Components<H extends Holder<C>, C> {
+public interface Components<H extends Holder<C>, C> extends Iterable<C> {
   /**
    * Returns the {@code T} component for the specified {@code int} holder
    * and {@link ComponentType}.

--- a/api/src/main/java/space/vectrix/inertia/injector/InjectionStructure.java
+++ b/api/src/main/java/space/vectrix/inertia/injector/InjectionStructure.java
@@ -47,7 +47,7 @@ public interface InjectionStructure<H extends Holder<C>, C> {
    * @return A map of component dependencies
    * @since 0.1.0
    */
-  @NonNull Map<Class<?>, Entry<ComponentDependency, ?, C>> components();
+  @NonNull Map<Class<? extends C>, Entry<ComponentDependency, ?, C>> components();
 
   /**
    * Returns a {@link Map} of {@link Class} types to {@link Entry}s
@@ -56,7 +56,7 @@ public interface InjectionStructure<H extends Holder<C>, C> {
    * @return A map of holder dependencies
    * @since 0.1.0
    */
-  @NonNull Map<Class<?>, Entry<HolderDependency, ?, H>> holders();
+  @NonNull Map<Class<? extends H>, Entry<HolderDependency, ?, H>> holders();
 
   /**
    * A dependency structure entry.
@@ -100,11 +100,12 @@ public interface InjectionStructure<H extends Holder<C>, C> {
      * @param target The structure target
      * @param componentInjectionFactory The component injection factory
      * @param holderInjectionFactory The holder injection factory
+     * @param <T> The specific target type
      * @return The new injection structure
      * @since 0.1.0
      */
-    @NonNull InjectionStructure<H, C> create(final @NonNull Class<?> target,
-                                             final InjectionMethod.@NonNull Factory<?, C> componentInjectionFactory,
-                                             final InjectionMethod.@NonNull Factory<?, H> holderInjectionFactory);
+    <T> @NonNull InjectionStructure<H, C> create(final @NonNull Class<T> target,
+                                                 final InjectionMethod.@NonNull Factory<?, C> componentInjectionFactory,
+                                                 final InjectionMethod.@NonNull Factory<?, H> holderInjectionFactory);
   }
 }

--- a/api/src/main/java/space/vectrix/inertia/processor/Processing.java
+++ b/api/src/main/java/space/vectrix/inertia/processor/Processing.java
@@ -22,76 +22,67 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package space.vectrix.inertia.holder;
+package space.vectrix.inertia.processor;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
 import space.vectrix.inertia.Universe;
+import space.vectrix.inertia.holder.Holder;
+
+import java.util.function.Function;
 
 /**
- * The holder resolver.
+ * The processing system.
  *
  * @param <H> The holder type
  * @param <C> The component type
  * @since 0.1.0
  */
-public interface HolderResolver<H extends Holder<C>, C> {
+public interface Processing<H extends Holder<C>, C> {
   /**
-   * Creates the {@code int} holder.
+   * Creates the {@code T} processor using the specified {@link Class} type
+   * and {@link Function}.
    *
-   * @return The holder index
+   * @param type The processor class
+   * @param processorFunction The processor function
+   * @param <T> The specific processor type
+   * @return The processor instance
    * @since 0.1.0
    */
-  int create();
+  <T extends Processor<H, C>> @NonNull T create(final @NonNull Class<T> type,
+                                                final @NonNull Function<Universe<H, C>, T> processorFunction);
 
   /**
-   * Creates the {@code T} holder using the specified {@link HolderFunction}.
+   * Ticks all the processors contained within this {@link Universe}.
    *
-   * @param holderFunction The holder function
-   * @param <T> The specific holder type
-   * @return The holder
+   * @return The tick index
    * @since 0.1.0
    */
-  <T extends H> @NonNull T create(final @NonNull HolderFunction<H, C, T> holderFunction);
+  int process();
 
   /**
-   * The function for creating a new holder from the supplied
-   * {@link Universe} and {@code index}.
+   * Handles any {@link Throwable}s caused in the processing phases.
    *
-   * @param <H> The holder type
-   * @param <C> The component type
-   * @param <T> The specific holder type
+   * @param throwable The processing exception
    * @since 0.1.0
    */
-  @FunctionalInterface
-  interface HolderFunction<H extends Holder<C>, C, T extends H> {
-    /**
-     * Creates a new {@link Holder} for the specified {@link Universe}
-     * with the specified {@code index}.
-     *
-     * @param universe The universe
-     * @param index The index
-     * @return The new holder
-     * @since 0.1.0
-     */
-    T apply(final @NonNull Universe<H, C> universe, final int index);
-  }
+  void processException(final @NonNull Throwable throwable);
 
   /**
-   * The factory for creating a {@link HolderResolver}.
+   * The factory for creating a {@link Processing} system.
    *
    * @since 0.1.0
    */
   @FunctionalInterface
   interface Factory {
     /**
-     * Creates a new {@link HolderResolver} for the specified {@link Universe}.
+     * Creates a new {@link Processing} system for the specified {@link Universe}.
      *
      * @param universe The universe
      * @param <H> The holder type
      * @param <C> The component type
-     * @return The holder resolver
+     * @return The processing system
      * @since 0.1.0
      */
-    <H extends Holder<C>, C> @NonNull HolderResolver<H, C> create(final @NonNull Universe<H, C> universe);
+    <H extends Holder<C>, C> @NonNull Processing<H, C> create(final @NonNull Universe<H, C> universe);
   }
 }

--- a/api/src/main/java/space/vectrix/inertia/processor/Processor.java
+++ b/api/src/main/java/space/vectrix/inertia/processor/Processor.java
@@ -1,0 +1,96 @@
+/*
+ * This file is part of inertia, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.inertia.processor;
+
+import static java.util.Objects.requireNonNull;
+
+import net.kyori.coffee.Ordered;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.inertia.holder.Holder;
+
+/**
+ * Represents a processor of holders.
+ *
+ * @since 0.1.0
+ */
+@FunctionalInterface
+public interface Processor<H extends Holder<C>, C> extends Ordered<Processor<H, C>> {
+  /**
+   * Returns an {@code int} for this processors priority.
+   *
+   * @return The processor priority
+   * @since 0.1.0
+   */
+  default int priority() {
+    return 0;
+  }
+
+  /**
+   * Returns {@code true} if this processor has been initialized, otherwise
+   * returns {@code false}.
+   *
+   * <p>In the case you need a custom implementation of {@link Processor#initialize()},
+   * this should return {@code false} by default, then be set {@code true} after
+   * {@link Processor#initialize()} has been called.</p>
+   *
+   * @return Whether this processor has been initialized
+   * @since 0.1.0
+   */
+  default boolean initialized() {
+    return true;
+  }
+
+  /**
+   * Called when the processor is initialized.
+   *
+   * <p>Requires {@link Processor#initialized()} to return {@code false}
+   * to be run in the processing loop.</p>
+   *
+   * @since 0.1.0
+   */
+  default void initialize() throws Throwable {}
+
+  /**
+   * Called when the processor is in the preparation stage at the
+   * beginning of each game tick.
+   *
+   * @since 0.1.0
+   */
+  default void prepare() throws Throwable {}
+
+  /**
+   * Called when the processor is in the execution stage in the
+   * middle of each game tick.
+   *
+   * @since 0.1.0
+   */
+  void execute() throws Throwable;
+
+  @Override
+  default int compareTo(final @NonNull Processor<H, C> other) {
+    requireNonNull(other, "other");
+    return Integer.compare(this.priority(), other.priority());
+  }
+}

--- a/api/src/main/java/space/vectrix/inertia/processor/Processors.java
+++ b/api/src/main/java/space/vectrix/inertia/processor/Processors.java
@@ -22,48 +22,60 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package space.vectrix.inertia.holder;
+package space.vectrix.inertia.processor;
 
+import net.kyori.coffee.math.range.i.IntRange;
 import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.inertia.holder.Holder;
 
 import java.util.Collection;
 import java.util.Optional;
 
 /**
- * The holder registry.
+ * The processor registry.
  *
  * @param <H> The holder type
  * @param <C> The component type
  * @since 0.1.0
  */
-public interface Holders<H extends Holder<C>, C> extends Iterable<H> {
+public interface Processors<H extends Holder<C>, C> extends Iterable<Processor<H, C>> {
   /**
-   * Returns the {@code T} holder with the specified {@code int}
-   * index, if it exists.
+   * Returns the {@code T} processor with the specified {@link Class}
+   * type, if it exists.
    *
-   * @param index The holder index
-   * @return The holder instance, if present
+   * @param type The processor class
+   * @param <T> The processor type
+   * @return The processor instance, if present
    * @since 0.1.0
    */
-  <T extends H> @NonNull Optional<T> get(final int index);
+  <T extends Processor<H, C>> @NonNull Optional<T> get(final @NonNull Class<T> type);
 
   /**
-   * Returns a {@link Collection} of {@code T} holders in this
-   * registry.
+   * Returns a {@link Collection} of {@link Processor}s with the
+   * specified {@code int} priority.
    *
-   * @param type The holder class
-   * @param <T> The specific holder type
-   * @return A collection of holder instances of that type
+   * @param priority The priority
+   * @return A collection of processor instances
    * @since 0.1.0
    */
-  <T extends H> @NonNull Collection<T> all(final @NonNull Class<T> type);
+  @NonNull Collection<? extends Processor<H, C>> all(final int priority);
 
   /**
-   * Returns a {@link Collection} of {@code H} holders in this
-   * registry.
+   * Returns a {@link Collection} of {@link Processor}s with
+   * the specified {@link IntRange} priority.
    *
-   * @return A collection of holder instances
+   * @param priorities The range of priorities
+   * @return A collection of processor instances
    * @since 0.1.0
    */
-  @NonNull Collection<? extends H> all();
+  @NonNull Collection<? extends Processor<H, C>> all(final @NonNull IntRange priorities);
+
+  /**
+   * Returns a {@link Collection} of {@link Processor}s in this
+   * registry.
+   *
+   * @return A collection of processor instances
+   * @since 0.1.0
+   */
+  @NonNull Collection<? extends Processor<H, C>> all();
 }

--- a/common/src/main/java/space/vectrix/inertia/UniverseImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/UniverseImpl.java
@@ -27,6 +27,7 @@ package space.vectrix.inertia;
 import static java.util.Objects.requireNonNull;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import space.vectrix.inertia.component.AbstractComponents;
 import space.vectrix.inertia.component.ComponentResolver;
 import space.vectrix.inertia.component.ComponentResolverImpl;
@@ -52,6 +53,7 @@ import space.vectrix.inertia.processor.Processor;
 import space.vectrix.inertia.processor.Processors;
 import space.vectrix.inertia.processor.ProcessorsImpl;
 
+import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
@@ -209,6 +211,24 @@ public final class UniverseImpl<H extends Holder<C>, C> implements Universe<H, C
   @Override
   public @NonNull ComponentTypes componentTypes() {
     return this.componentTypes;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hashCode(this.id);
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(other == this) return true;
+    if(!(other instanceof Universe)) return false;
+    final Universe<?, ?> that = (Universe<?, ?>) other;
+    return this.id.equals(that.id());
+  }
+
+  @Override
+  public String toString() {
+    return "Universe{id=" + this.id + "}";
   }
 
   public static final class Builder<H extends Holder<C>, C> implements Universe.Builder<H, C> {

--- a/common/src/main/java/space/vectrix/inertia/UniverseImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/UniverseImpl.java
@@ -209,7 +209,7 @@ public final class UniverseImpl<H extends Holder<C>, C> implements Universe<H, C
   }
 
   @Override
-  public @NonNull ComponentTypes componentTypes() {
+  public @NonNull ComponentTypes types() {
     return this.componentTypes;
   }
 

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
@@ -45,7 +45,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @SuppressWarnings("UnstableApiUsage")
 public final class ComponentResolverImpl<H extends Holder<C>, C> implements ComponentResolver<H, C> {
   private final AtomicInteger index = new AtomicInteger();
-  private final MutableGraph<ComponentTypeImpl<H, C>> componentDependencies = GraphBuilder.undirected()
+  private final MutableGraph<ComponentTypeImpl<H, C>> dependencies = GraphBuilder.undirected()
     .allowsSelfLoops(false)
     .expectedNodeCount(1000)
     .build();
@@ -113,9 +113,9 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
       ));
     });
     if(parent != null) {
-      this.componentDependencies.putEdge(parent, componentType);
+      this.dependencies.putEdge(parent, componentType);
     } else {
-      this.componentDependencies.addNode(componentType);
+      this.dependencies.addNode(componentType);
     }
     final InjectionStructure<H, C> structure = componentType.structure();
     for(final Map.Entry<Class<?>, InjectionStructure.Entry<ComponentDependency, ?, C>> entry : structure.components().entrySet()) {
@@ -141,7 +141,7 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
         for(final InjectionStructure.Entry<HolderDependency, ?, H> holderEntry : structure.holders().values()) {
           this.injectMember(holderEntry.method(), componentInstance, holder);
         }
-        for(final ComponentTypeImpl<H, C> dependency : this.componentDependencies.adjacentNodes(componentType)) {
+        for(final ComponentTypeImpl<H, C> dependency : this.dependencies.adjacentNodes(componentType)) {
           if(parentType != null && dependency.index() == componentType.index()) continue;
           final InjectionStructure.Entry<ComponentDependency, ?, C> componentInjection = structure.components().get(dependency.type());
           final C dependencyInstance = holder.get(dependency).orElseGet(() -> {

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
@@ -103,7 +103,7 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
                                               final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
                                               final InjectionMethod.Factory<?, C> componentInjector,
                                               final InjectionMethod.Factory<?, H> holderInjector) {
-    final ComponentTypeImpl<H, C> componentType = ((ComponentTypesImpl<H, C>) this.universe.componentTypes()).put(type, key -> {
+    final ComponentTypeImpl<H, C> componentType = ((ComponentTypesImpl<H, C>) this.universe.types()).put(type, key -> {
       final Component component = type.getAnnotation(Component.class);
       if(component == null) throw new IllegalArgumentException("Target type must have a component annotation!");
       return new ComponentTypeImpl<>(this.index.getAndIncrement(), component.id(), component.name(), type, componentStructureFactory.create(

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentResolverImpl.java
@@ -56,10 +56,10 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
   }
 
   @Override
-  public @NonNull ComponentType resolve(final @NonNull Class<?> type,
-                                        final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
-                                        final InjectionMethod.@NonNull Factory<?, C> componentInjector,
-                                        final InjectionMethod.@NonNull Factory<?, H> holderInjector) {
+  public <T extends C> @NonNull ComponentType resolve(final @NonNull Class<T> type,
+                                                      final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
+                                                      final InjectionMethod.@NonNull Factory<?, C> componentInjector,
+                                                      final InjectionMethod.@NonNull Factory<?, H> holderInjector) {
     requireNonNull(type, "type");
     requireNonNull(componentStructureFactory, "componentStructureFactory");
     return this.resolve(
@@ -98,11 +98,11 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
   }
 
   @SuppressWarnings("unchecked")
-  private ComponentType resolve(final @Nullable ComponentTypeImpl<H, C> parent,
-                                final @NonNull Class<?> type,
-                                final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
-                                final InjectionMethod.Factory<?, C> componentInjector,
-                                final InjectionMethod.Factory<?, H> holderInjector) {
+  private <T extends C> ComponentType resolve(final @Nullable ComponentTypeImpl<H, C> parent,
+                                              final @NonNull Class<T> type,
+                                              final InjectionStructure.@NonNull Factory<H, C> componentStructureFactory,
+                                              final InjectionMethod.Factory<?, C> componentInjector,
+                                              final InjectionMethod.Factory<?, H> holderInjector) {
     final ComponentTypeImpl<H, C> componentType = ((ComponentTypesImpl<H, C>) this.universe.componentTypes()).put(type, key -> {
       final Component component = type.getAnnotation(Component.class);
       if(component == null) throw new IllegalArgumentException("Target type must have a component annotation!");
@@ -118,7 +118,7 @@ public final class ComponentResolverImpl<H extends Holder<C>, C> implements Comp
       this.dependencies.addNode(componentType);
     }
     final InjectionStructure<H, C> structure = componentType.structure();
-    for(final Map.Entry<Class<?>, InjectionStructure.Entry<ComponentDependency, ?, C>> entry : structure.components().entrySet()) {
+    for(final Map.Entry<Class<? extends C>, InjectionStructure.Entry<ComponentDependency, ?, C>> entry : structure.components().entrySet()) {
       componentType.dependency(new ComponentLinkImpl(
         this.resolve(componentType, entry.getKey(), componentStructureFactory, componentInjector, holderInjector),
         entry.getValue().annotation().optional()

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentTypeImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentTypeImpl.java
@@ -27,6 +27,7 @@ package space.vectrix.inertia.component;
 import static java.util.Objects.requireNonNull;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import space.vectrix.flare.SyncMap;
 import space.vectrix.inertia.holder.Holder;
 import space.vectrix.inertia.injector.InjectionStructure;
@@ -98,5 +99,25 @@ public final class ComponentTypeImpl<H extends Holder<C>, C> implements Componen
    */
   public void dependency(final @NonNull ComponentLink link) {
     this.dependencies.add(link);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.index;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(other == this) return true;
+    if(!(other instanceof ComponentType)) return false;
+    final ComponentType that = (ComponentType) other;
+    return this.index == that.index();
+  }
+
+  @Override
+  public String toString() {
+    return "ComponentType{index=" + this.index + ", id=" + this.id
+      + ", name=" + this.name + ", type=" + this.component.getSimpleName()
+      + "}";
   }
 }

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentTypesImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentTypesImpl.java
@@ -40,8 +40,8 @@ import java.util.Optional;
 
 public final class ComponentTypesImpl<H extends Holder<C>, C> implements ComponentTypes {
   private final Int2ObjectMap<ComponentTypeImpl<H, C>> components = new Int2ObjectOpenHashMap<>(100);
-  private final Map<Class<?>, ComponentTypeImpl<H, C>> componentsTyped = new IdentityHashMap<>(50);
-  private final Map<String, ComponentTypeImpl<H, C>> componentsNamed = new HashMap<>(50);
+  private final Map<Class<?>, ComponentTypeImpl<H, C>> typed = new IdentityHashMap<>(50);
+  private final Map<String, ComponentTypeImpl<H, C>> named = new HashMap<>(50);
   private final Object lock = new Object();
 
   public ComponentTypesImpl() {}
@@ -57,7 +57,7 @@ public final class ComponentTypesImpl<H extends Holder<C>, C> implements Compone
   public @NonNull Optional<ComponentType> get(final @NonNull Class<?> type) {
     requireNonNull(type, "type");
     synchronized(this.lock) {
-      return Optional.ofNullable(this.componentsTyped.get(type));
+      return Optional.ofNullable(this.typed.get(type));
     }
   }
 
@@ -65,7 +65,7 @@ public final class ComponentTypesImpl<H extends Holder<C>, C> implements Compone
   public @NonNull Optional<ComponentType> get(final @NonNull String identifier) {
     requireNonNull(identifier, "identifier");
     synchronized(this.lock) {
-      return Optional.ofNullable(this.componentsNamed.get(identifier));
+      return Optional.ofNullable(this.named.get(identifier));
     }
   }
 
@@ -86,10 +86,10 @@ public final class ComponentTypesImpl<H extends Holder<C>, C> implements Compone
    */
   public @NonNull ComponentTypeImpl<H, C> put(final @NonNull Class<?> type, final @NonNull Function<Class<?>, ComponentTypeImpl<H, C>> computation) {
     synchronized(this.lock) {
-      return this.componentsTyped.computeIfAbsent(type, key -> {
+      return this.typed.computeIfAbsent(type, key -> {
         final ComponentTypeImpl<H, C> componentType = computation.apply(key);
         this.components.put(componentType.index(), componentType);
-        this.componentsNamed.put(componentType.id(), componentType);
+        this.named.put(componentType.id(), componentType);
         return componentType;
       });
     }

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentsImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentsImpl.java
@@ -41,8 +41,8 @@ import java.util.List;
 import java.util.Optional;
 
 public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractComponents<H, C> {
-  private final Int2ObjectMap<C> componentInstances = new Int2ObjectOpenHashMap<>(100);
-  private final Int2ObjectMap<IntSet> componentInstancesGrouped = new Int2ObjectOpenHashMap<>(10);
+  private final Int2ObjectMap<C> components = new Int2ObjectOpenHashMap<>(100);
+  private final Int2ObjectMap<IntSet> holders = new Int2ObjectOpenHashMap<>(10);
 
   public ComponentsImpl() {}
 
@@ -51,7 +51,7 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
   public <T extends C> @NonNull Optional<T> get(final int holder, final @NonNull ComponentType componentType) {
     requireNonNull(componentType, "componentType");
     synchronized(this.lock) {
-      return Optional.ofNullable((T) this.componentInstances.get(this.getCombinedIndex(holder, componentType.index())));
+      return Optional.ofNullable((T) this.components.get(this.getCombinedIndex(holder, componentType.index())));
     }
   }
 
@@ -64,11 +64,11 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
   @Override
   public @NonNull Collection<? extends C> all(final int holder) {
     synchronized(this.lock) {
-      final IntSet components = this.componentInstancesGrouped.get(holder);
+      final IntSet components = this.holders.get(holder);
       if(components == null) return Collections.emptySet();
       final List<C> instances = new ArrayList<>(components.size());
       for(final int component : components) {
-        instances.add(this.componentInstances.get(this.getCombinedIndex(holder, component)));
+        instances.add(this.components.get(this.getCombinedIndex(holder, component)));
       }
       return instances;
     }
@@ -82,20 +82,20 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
 
   @Override
   public @NonNull Collection<? extends C> all() {
-    return this.componentInstances.values();
+    return this.components.values();
   }
 
   @Override
   public @NonNull Iterator<C> iterator() {
-    return this.componentInstances.values().iterator();
+    return this.components.values().iterator();
   }
 
   @Override
   public <T extends C> boolean put(final int holder, final @NonNull ComponentType componentType, final @NonNull T component) {
     synchronized(this.lock) {
       final int index = this.getCombinedIndex(holder, componentType.index());
-      if (this.componentInstances.putIfAbsent(index, component) == null) {
-        this.componentInstancesGrouped.computeIfAbsent(holder, key -> new IntOpenHashSet()).add(componentType.index());
+      if (this.components.putIfAbsent(index, component) == null) {
+        this.holders.computeIfAbsent(holder, key -> new IntOpenHashSet()).add(componentType.index());
         return true;
       }
       return false;
@@ -105,8 +105,8 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
   @Override
   public boolean remove(final int holder, final @NonNull ComponentType componentType) {
     synchronized(this.lock) {
-      if (this.componentInstances.remove(this.getCombinedIndex(holder, componentType.index())) != null) {
-        final IntSet components = this.componentInstancesGrouped.get(holder);
+      if (this.components.remove(this.getCombinedIndex(holder, componentType.index())) != null) {
+        final IntSet components = this.holders.get(holder);
         if (components != null) {
           components.remove(componentType.index());
           return true;
@@ -119,10 +119,10 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
   @Override
   public void remove(final int holder) {
     synchronized(this.lock) {
-      final IntSet components = this.componentInstancesGrouped.remove(holder);
+      final IntSet components = this.holders.remove(holder);
       if (components != null) {
         for (final int component : components) {
-          this.componentInstances.remove(this.getCombinedIndex(holder, component));
+          this.components.remove(this.getCombinedIndex(holder, component));
         }
       }
     }

--- a/common/src/main/java/space/vectrix/inertia/component/ComponentsImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/component/ComponentsImpl.java
@@ -36,6 +36,7 @@ import space.vectrix.inertia.holder.Holder;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Optional;
 
@@ -82,6 +83,11 @@ public final class ComponentsImpl<H extends Holder<C>, C> extends AbstractCompon
   @Override
   public @NonNull Collection<? extends C> all() {
     return this.componentInstances.values();
+  }
+
+  @Override
+  public @NonNull Iterator<C> iterator() {
+    return this.componentInstances.values().iterator();
   }
 
   @Override

--- a/common/src/main/java/space/vectrix/inertia/holder/AbstractHolder.java
+++ b/common/src/main/java/space/vectrix/inertia/holder/AbstractHolder.java
@@ -27,6 +27,7 @@ package space.vectrix.inertia.holder;
 import static java.util.Objects.requireNonNull;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import space.vectrix.inertia.Universe;
 import space.vectrix.inertia.component.ComponentType;
 
@@ -76,5 +77,23 @@ public abstract class AbstractHolder<C> implements Holder<C> {
   @Override
   public void clear() {
     this.universe.removeComponents(this);
+  }
+
+  @Override
+  public int hashCode() {
+    return this.index;
+  }
+
+  @Override
+  public boolean equals(final @Nullable Object other) {
+    if(other == this) return true;
+    if(!(other instanceof AbstractHolder)) return false;
+    final AbstractHolder<?> that = (AbstractHolder<?>) other;
+    return this.index == that.index();
+  }
+
+  @Override
+  public String toString() {
+    return "Holder{index=" + this.index + ", universe=" + this.universe.id() + "}";
   }
 }

--- a/common/src/main/java/space/vectrix/inertia/holder/AbstractHolder.java
+++ b/common/src/main/java/space/vectrix/inertia/holder/AbstractHolder.java
@@ -44,7 +44,7 @@ import java.util.Optional;
  * @since 0.1.0
  */
 public abstract class AbstractHolder<C> implements Holder<C> {
-  private final Universe<Holder<C>, C> universe;
+  protected final Universe<Holder<C>, C> universe;
   private final int index;
 
   protected AbstractHolder(final @NonNull Universe<Holder<C>, C> universe, final int index) {

--- a/common/src/main/java/space/vectrix/inertia/holder/HoldersImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/holder/HoldersImpl.java
@@ -40,8 +40,8 @@ import java.util.Optional;
 
 public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H, C> {
   private final IntSet holders = new IntOpenHashSet(100);
-  private final Int2ObjectMap<H> holderInstances = new Int2ObjectOpenHashMap<>(100);
-  private final Multimap<Class<?>, H> holderInstancesTyped = HashMultimap.create(10, 50);
+  private final Int2ObjectMap<H> instances = new Int2ObjectOpenHashMap<>(100);
+  private final Multimap<Class<?>, H> typed = HashMultimap.create(10, 50);
 
   public HoldersImpl() {}
 
@@ -49,7 +49,7 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
   @SuppressWarnings("unchecked")
   public <T extends H> @NonNull Optional<T> get(final int index) {
     synchronized(this.lock) {
-      return Optional.ofNullable((T) this.holderInstances.get(index));
+      return Optional.ofNullable((T) this.instances.get(index));
     }
   }
 
@@ -58,18 +58,18 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
   public <T extends H> @NonNull Collection<T> all(final @NonNull Class<T> type) {
     requireNonNull(type, "type");
     synchronized(this.lock) {
-      return (Collection<T>) this.holderInstancesTyped.get(type);
+      return (Collection<T>) this.typed.get(type);
     }
   }
 
   @Override
   public @NonNull Collection<? extends H> all() {
-    return this.holderInstances.values();
+    return this.instances.values();
   }
 
   @Override
   public @NonNull Iterator<H> iterator() {
-    return this.holderInstances.values().iterator();
+    return this.instances.values().iterator();
   }
 
   @Override
@@ -83,8 +83,8 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
   public <T extends H> void put(final int index, final @NonNull T holder) {
     synchronized(this.lock) {
       if (this.put(index)) {
-        this.holderInstances.put(index, holder);
-        this.holderInstancesTyped.put(holder.getClass(), holder);
+        this.instances.put(index, holder);
+        this.typed.put(holder.getClass(), holder);
       }
     }
   }
@@ -108,9 +108,9 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
   }
 
   private void removeInstance(final int index) {
-    final H holder = this.holderInstances.remove(index);
+    final H holder = this.instances.remove(index);
     if(holder != null) {
-      this.holderInstancesTyped.remove(holder.getClass(), holder);
+      this.typed.remove(holder.getClass(), holder);
     }
   }
 }

--- a/common/src/main/java/space/vectrix/inertia/holder/HoldersImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/holder/HoldersImpl.java
@@ -35,6 +35,7 @@ import it.unimi.dsi.fastutil.ints.IntSet;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.Optional;
 
 public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H, C> {
@@ -54,7 +55,7 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
 
   @Override
   @SuppressWarnings("unchecked")
-  public <T extends H> @NonNull Collection<T> get(final @NonNull Class<T> type) {
+  public <T extends H> @NonNull Collection<T> all(final @NonNull Class<T> type) {
     requireNonNull(type, "type");
     synchronized(this.lock) {
       return (Collection<T>) this.holderInstancesTyped.get(type);
@@ -64,6 +65,11 @@ public final class HoldersImpl<H extends Holder<C>, C> extends AbstractHolders<H
   @Override
   public @NonNull Collection<? extends H> all() {
     return this.holderInstances.values();
+  }
+
+  @Override
+  public @NonNull Iterator<H> iterator() {
+    return this.holderInstances.values().iterator();
   }
 
   @Override

--- a/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionMethodFactory.java
+++ b/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionMethodFactory.java
@@ -29,14 +29,14 @@ import static java.util.Objects.requireNonNull;
 import org.checkerframework.checker.nullness.qual.NonNull;
 
 public final class DummyInjectionMethodFactory<T, M> implements InjectionMethod.Factory<T, M> {
-  private final DummyMemberInjector<T, M> dummyInjector = new DummyMemberInjector<>();
+  private final DummyMemberInjector<T, M> injector = new DummyMemberInjector<>();
 
   public DummyInjectionMethodFactory() {}
 
   @Override
   public <I> @NonNull InjectionMethod<T, M> create(final @NonNull I input) throws Exception {
     requireNonNull(input, "input");
-    return this.dummyInjector;
+    return this.injector;
   }
 
   /* package */ static final class DummyMemberInjector<T, M> implements InjectionMethod<T, M> {

--- a/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionStructureFactory.java
+++ b/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionStructureFactory.java
@@ -35,7 +35,7 @@ import java.util.Collections;
 import java.util.Map;
 
 public final class DummyInjectionStructureFactory<H extends Holder<C>, C> implements InjectionStructure.Factory<H, C> {
-  private final DummyInjectionStructure<H, C> dummyStructure = new DummyInjectionStructure<>();
+  private final DummyInjectionStructure<H, C> structure = new DummyInjectionStructure<>();
 
   public DummyInjectionStructureFactory() {}
 
@@ -44,7 +44,7 @@ public final class DummyInjectionStructureFactory<H extends Holder<C>, C> implem
                                                   final InjectionMethod.@NonNull Factory<?, C> componentInjectionFactory,
                                                   final InjectionMethod.@NonNull Factory<?, H> holderInjectionFactory) {
     requireNonNull(target, "target");
-    return this.dummyStructure;
+    return this.structure;
   }
 
   /* package */ static final class DummyInjectionStructure<H extends Holder<C>, C> implements InjectionStructure<H, C> {

--- a/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionStructureFactory.java
+++ b/common/src/main/java/space/vectrix/inertia/injector/DummyInjectionStructureFactory.java
@@ -40,21 +40,21 @@ public final class DummyInjectionStructureFactory<H extends Holder<C>, C> implem
   public DummyInjectionStructureFactory() {}
 
   @Override
-  public @NonNull InjectionStructure<H, C> create(final @NonNull Class<?> target,
-                                                  final InjectionMethod.@NonNull Factory<?, C> componentInjectionFactory,
-                                                  final InjectionMethod.@NonNull Factory<?, H> holderInjectionFactory) {
+  public <T> @NonNull InjectionStructure<H, C> create(final @NonNull Class<T> target,
+                                                      final InjectionMethod.@NonNull Factory<?, C> componentInjectionFactory,
+                                                      final InjectionMethod.@NonNull Factory<?, H> holderInjectionFactory) {
     requireNonNull(target, "target");
     return this.structure;
   }
 
   /* package */ static final class DummyInjectionStructure<H extends Holder<C>, C> implements InjectionStructure<H, C> {
     @Override
-    public @NonNull Map<Class<?>, Entry<ComponentDependency, ?, C>> components() {
+    public @NonNull Map<Class<? extends C>, Entry<ComponentDependency, ?, C>> components() {
       return Collections.emptyMap();
     }
 
     @Override
-    public @NonNull Map<Class<?>, Entry<HolderDependency, ?, H>> holders() {
+    public @NonNull Map<Class<? extends H>, Entry<HolderDependency, ?, H>> holders() {
       return Collections.emptyMap();
     }
   }

--- a/common/src/main/java/space/vectrix/inertia/processor/AbstractProcessors.java
+++ b/common/src/main/java/space/vectrix/inertia/processor/AbstractProcessors.java
@@ -22,48 +22,43 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
  * THE SOFTWARE.
  */
-package space.vectrix.inertia.holder;
+package space.vectrix.inertia.processor;
 
 import org.checkerframework.checker.nullness.qual.NonNull;
-
-import java.util.Collection;
-import java.util.Optional;
+import space.vectrix.inertia.holder.Holder;
 
 /**
- * The holder registry.
+ * {@inheritDoc}
+ *
+ * Provides methods to use internally for storing and removing
+ * {@link Processor}s.
  *
  * @param <H> The holder type
  * @param <C> The component type
  * @since 0.1.0
  */
-public interface Holders<H extends Holder<C>, C> extends Iterable<H> {
-  /**
-   * Returns the {@code T} holder with the specified {@code int}
-   * index, if it exists.
-   *
-   * @param index The holder index
-   * @return The holder instance, if present
-   * @since 0.1.0
-   */
-  <T extends H> @NonNull Optional<T> get(final int index);
+public abstract class AbstractProcessors<H extends Holder<C>, C> implements Processors<H, C> {
+  protected final Object lock = new Object();
 
   /**
-   * Returns a {@link Collection} of {@code T} holders in this
-   * registry.
+   * Returns {@code true} if the specified {@code T} processor is stored
+   * successfully, otherwise returns {@code false}.
    *
-   * @param type The holder class
-   * @param <T> The specific holder type
-   * @return A collection of holder instances of that type
+   * @param type The processor class
+   * @param processor The processor instance
+   * @param <T> The specific processor type
+   * @return Whether the processor was stored
    * @since 0.1.0
    */
-  <T extends H> @NonNull Collection<T> all(final @NonNull Class<T> type);
+  public abstract <T extends Processor<H, C>> boolean put(final Class<T> type, final @NonNull T processor);
 
   /**
-   * Returns a {@link Collection} of {@code H} holders in this
+   * Removes the processor with the specified {@link Class} from the
    * registry.
    *
-   * @return A collection of holder instances
+   * @param type The processor class
+   * @return Whether the processor was removed
    * @since 0.1.0
    */
-  @NonNull Collection<? extends H> all();
+  public abstract boolean remove(final @NonNull Class<? extends Processor<H, C>> type);
 }

--- a/common/src/main/java/space/vectrix/inertia/processor/ProcessingImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/processor/ProcessingImpl.java
@@ -1,0 +1,99 @@
+/*
+ * This file is part of inertia, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.inertia.processor;
+
+import static java.util.Objects.requireNonNull;
+
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.inertia.Universe;
+import space.vectrix.inertia.holder.Holder;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Function;
+
+public final class ProcessingImpl<H extends Holder<C>, C> implements Processing<H, C> {
+  private final AtomicInteger index = new AtomicInteger();
+  private final Universe<H, C> universe;
+
+  /* package */ ProcessingImpl(final Universe<H, C> universe) {
+    this.universe = universe;
+  }
+
+  @Override
+  public <T extends Processor<H, C>> @NonNull T create(final @NonNull Class<T> type, final @NonNull Function<Universe<H, C>, T> processorFunction) {
+    requireNonNull(type, "type");
+    requireNonNull(processorFunction, "processorFunction");
+    final AbstractProcessors<H, C> processors = (AbstractProcessors<H, C>) this.universe.processors();
+    final T processorInstance = processorFunction.apply(this.universe);
+    processors.put(type, processorInstance);
+    return processorInstance;
+  }
+
+  @Override
+  public int process() {
+    final AbstractProcessors<H, C> processors = (AbstractProcessors<H, C>) this.universe.processors();
+    final int index = this.index.getAndIncrement();
+    final List<Processor<H, C>> collection = new ArrayList<>(processors.all());
+    Collections.sort(collection);
+    for(final Processor<H, C> processor : collection) {
+      boolean run = true;
+      try {
+        if(!processor.initialized()) processor.initialize();
+      } catch(final Throwable throwable) {
+        run = false;
+        this.processException(throwable);
+      }
+      try {
+        if(run) processor.prepare();
+      } catch(final Throwable throwable) {
+        run = false;
+        this.processException(throwable);
+      }
+      try {
+        if(run) processor.execute();
+      } catch(final Throwable throwable) {
+        this.processException(throwable);
+      }
+    }
+    return index;
+  }
+
+  @Override
+  public void processException(final @NonNull Throwable throwable) {
+    final RuntimeException printer = new RuntimeException("Encountered a processing error: ", throwable);
+    printer.printStackTrace();
+  }
+
+  public static final class Factory implements Processing.Factory {
+    @Override
+    public @NonNull <H extends Holder<C>, C> Processing<H, C> create(final @NonNull Universe<H, C> universe) {
+      requireNonNull(universe, "universe");
+      return new ProcessingImpl<>(universe);
+    }
+  }
+}

--- a/common/src/main/java/space/vectrix/inertia/processor/ProcessorsImpl.java
+++ b/common/src/main/java/space/vectrix/inertia/processor/ProcessorsImpl.java
@@ -1,0 +1,90 @@
+/*
+ * This file is part of inertia, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.inertia.processor;
+
+import net.kyori.coffee.math.range.i.IntRange;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import space.vectrix.inertia.holder.Holder;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+public final class ProcessorsImpl<H extends Holder<C>, C> extends AbstractProcessors<H, C> {
+  private final Map<Class<? extends Processor<H, C>>, Processor<H, C>> processors = new IdentityHashMap<>(10);
+
+  public ProcessorsImpl() {}
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public @NonNull <T extends Processor<H, C>> Optional<T> get(final @NonNull Class<T> type) {
+    synchronized(this.lock) {
+      return Optional.ofNullable((T) this.processors.get(type));
+    }
+  }
+
+  @Override
+  public @NonNull Collection<? extends Processor<H, C>> all(final int priority) {
+    final List<Processor<H, C>> processors = new ArrayList<>(this.processors.size());
+    for(final Processor<H, C> processor : this.processors.values()) {
+      if(processor.priority() == priority) processors.add(processor);
+    }
+    return processors;
+  }
+
+  @Override
+  public @NonNull Collection<? extends Processor<H, C>> all(final @NonNull IntRange priorities) {
+    final List<Processor<H, C>> processors = new ArrayList<>(this.processors.size());
+    for(final Processor<H, C> processor : this.processors.values()) {
+      if(priorities.test(processor.priority())) processors.add(processor);
+    }
+    return processors;
+  }
+
+  @Override
+  public @NonNull Collection<? extends Processor<H, C>> all() {
+    return Collections.unmodifiableCollection(this.processors.values());
+  }
+
+  @Override
+  public @NonNull Iterator<Processor<H, C>> iterator() {
+    return this.processors.values().iterator();
+  }
+
+  @Override
+  public <T extends Processor<H, C>> boolean put(final Class<T> type, final @NonNull T processor) {
+    return this.processors.putIfAbsent(type, processor) == null;
+  }
+
+  @Override
+  public boolean remove(final @NonNull Class<? extends Processor<H, C>> type) {
+    return this.processors.remove(type) != null;
+  }
+}

--- a/common/src/test/java/space/vectrix/inertia/AbstractUniverseTest.java
+++ b/common/src/test/java/space/vectrix/inertia/AbstractUniverseTest.java
@@ -32,6 +32,7 @@ import org.junit.jupiter.api.Test;
 import space.vectrix.inertia.component.ComponentType;
 import space.vectrix.inertia.holder.AbstractHolder;
 import space.vectrix.inertia.holder.Holder;
+import space.vectrix.inertia.processor.Processor;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -81,7 +82,17 @@ abstract class AbstractUniverseTest {
 
   @Component(id = "test", name = "Test")
   public static final class TestComponent {
+    private int tick;
+
     public TestComponent() {}
+
+    public int getTick() {
+      return this.tick;
+    }
+
+    public int next() {
+      return ++this.tick;
+    }
   }
 
   @Component(id = "another", name = "Another")
@@ -90,12 +101,18 @@ abstract class AbstractUniverseTest {
   }
 
   static final class TestHolder extends AbstractHolder<Object> {
-    private final Universe<Holder<Object>, Object> universe;
-
     protected TestHolder(final Universe<Holder<Object>, Object> universe, final int index) {
       super(universe, index);
+    }
 
-      this.universe = universe;
+    public Universe<Holder<Object>, Object> universe() {
+      return this.universe;
+    }
+  }
+
+  static final class AnotherHolder extends AbstractHolder<Object> {
+    protected AnotherHolder(final Universe<Holder<Object>, Object> universe, final int index) {
+      super(universe, index);
     }
 
     public Universe<Holder<Object>, Object> universe() {

--- a/common/src/test/java/space/vectrix/inertia/ComponentTest.java
+++ b/common/src/test/java/space/vectrix/inertia/ComponentTest.java
@@ -46,12 +46,12 @@ class ComponentTest extends AbstractUniverseTest {
     final CompletableFuture<ComponentType> typeFuture = universe.resolveComponent(TestComponent.class);
     final ComponentType componentType = assertDoesNotThrow(() -> typeFuture.get());
     assertDoesNotThrow(() -> universe.createComponent(holder, componentType).get());
-    assertTrue(universe.componentTypes().get(0).isPresent());
-    assertFalse(universe.componentTypes().get(1).isPresent());
-    assertTrue(universe.componentTypes().get(TestComponent.class).isPresent());
-    assertFalse(universe.componentTypes().get(Object.class).isPresent());
-    assertTrue(universe.componentTypes().get("test").isPresent());
-    assertFalse(universe.componentTypes().get("fake").isPresent());
-    assertThat(universe.componentTypes().all()).hasSize(1);
+    assertTrue(universe.types().get(0).isPresent());
+    assertFalse(universe.types().get(1).isPresent());
+    assertTrue(universe.types().get(TestComponent.class).isPresent());
+    assertFalse(universe.types().get(Object.class).isPresent());
+    assertTrue(universe.types().get("test").isPresent());
+    assertFalse(universe.types().get("fake").isPresent());
+    assertThat(universe.types().all()).hasSize(1);
   }
 }

--- a/common/src/test/java/space/vectrix/inertia/HolderTest.java
+++ b/common/src/test/java/space/vectrix/inertia/HolderTest.java
@@ -45,7 +45,7 @@ class HolderTest extends AbstractUniverseTest {
     assertDoesNotThrow(() -> universe.createHolder(TestHolder::new).get());
     assertTrue(universe.holders().get(0).isPresent());
     assertFalse(universe.holders().get(1).isPresent());
-    assertFalse(universe.holders().get(TestHolder.class).isEmpty());
+    assertFalse(universe.holders().all(TestHolder.class).isEmpty());
     assertThat(universe.holders().all()).hasSize(1);
   }
 

--- a/common/src/test/java/space/vectrix/inertia/HolderTest.java
+++ b/common/src/test/java/space/vectrix/inertia/HolderTest.java
@@ -45,6 +45,7 @@ class HolderTest extends AbstractUniverseTest {
     assertDoesNotThrow(() -> universe.createHolder(TestHolder::new).get());
     assertTrue(universe.holders().get(0).isPresent());
     assertFalse(universe.holders().get(1).isPresent());
+    assertTrue(universe.holders().all(AnotherHolder.class).isEmpty());
     assertFalse(universe.holders().all(TestHolder.class).isEmpty());
     assertThat(universe.holders().all()).hasSize(1);
   }

--- a/common/src/test/java/space/vectrix/inertia/ProcessorTest.java
+++ b/common/src/test/java/space/vectrix/inertia/ProcessorTest.java
@@ -1,0 +1,121 @@
+/*
+ * This file is part of inertia, licensed under the MIT License (MIT).
+ *
+ * Copyright (c) vectrix.space <https://vectrix.space/>
+ * Copyright (c) contributors
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+package space.vectrix.inertia;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import net.kyori.coffee.math.range.i.IntRange;
+import org.junit.jupiter.api.Test;
+import space.vectrix.inertia.component.ComponentType;
+import space.vectrix.inertia.holder.Holder;
+import space.vectrix.inertia.processor.Processor;
+
+class ProcessorTest extends AbstractUniverseTest {
+  @Test
+  void testGet() {
+    final Universe<Holder<Object>, Object> universe = new UniverseImpl.Builder<>()
+      .id("processor_universe")
+      .build();
+    assertDoesNotThrow(() -> universe.createProcessor(TestProcessor.class, TestProcessor::new).get());
+    assertTrue(universe.processors().get(TestProcessor.class).isPresent());
+    assertFalse(universe.processors().get(AnotherProcessor.class).isPresent());
+    assertThat(universe.processors().all(0)).isNotEmpty();
+    assertThat(universe.processors().all(1)).isEmpty();
+    assertThat(universe.processors().all(IntRange.between(0, 1))).isNotEmpty();
+    assertThat(universe.processors().all()).isNotEmpty();
+    assertDoesNotThrow(() -> universe.createProcessor(AnotherProcessor.class, AnotherProcessor::new).get());
+    assertThat(universe.processors().all(2)).isNotEmpty();
+    assertThat(universe.processors().all(IntRange.between(1, 2))).isNotEmpty();
+    assertThat(universe.processors().all(IntRange.between(3, 4))).isEmpty();
+  }
+
+  @Test
+  void testProcessing() {
+    final Universe<Holder<Object>, Object> universe = new UniverseImpl.Builder<>()
+      .id("processor_universe")
+      .build();
+    final TestHolder holder = assertDoesNotThrow(() -> universe.createHolder(TestHolder::new).get());
+    final ComponentType componentType = assertDoesNotThrow(() -> universe.resolveComponent(TestComponent.class).get());
+    final TestComponent component = assertDoesNotThrow(() -> universe.<TestComponent>createComponent(holder, componentType).get());
+    assertDoesNotThrow(() -> universe.createProcessor(TestProcessor.class, TestProcessor::new).get());
+    assertEquals(0, universe.tick());
+    assertEquals(1, component.getTick());
+    assertDoesNotThrow(() -> universe.createProcessor(AnotherProcessor.class, AnotherProcessor::new).get());
+    assertEquals(1, universe.tick());
+    assertEquals(3, component.getTick());
+  }
+
+  @Test
+  void testProcessorRemove() {
+    final Universe<Holder<Object>, Object> universe = new UniverseImpl.Builder<>()
+      .id("processor_universe")
+      .build();
+    assertDoesNotThrow(() -> universe.createProcessor(TestProcessor.class, TestProcessor::new).get());
+    assertTrue(universe.processors().get(TestProcessor.class).isPresent());
+    assertTrue(universe.removeProcessor(TestProcessor.class));
+    assertFalse(universe.processors().get(TestProcessor.class).isPresent());
+  }
+
+  static final class TestProcessor implements Processor<Holder<Object>, Object> {
+    private final Universe<Holder<Object>, Object> universe;
+
+    public TestProcessor(final Universe<Holder<Object>, Object> universe) {
+      this.universe = universe;
+    }
+
+    @Override
+    public void execute() throws Throwable {
+      final ComponentType testComponent = this.universe.resolveComponent(TestComponent.class).get();
+      for(final Holder<Object> holder : this.universe.holders().all()) {
+        holder.<TestComponent>get(testComponent).ifPresent(TestComponent::next);
+      }
+    }
+  }
+
+  static final class AnotherProcessor implements Processor<Holder<Object>, Object> {
+    private final Universe<Holder<Object>, Object> universe;
+
+    public AnotherProcessor(final Universe<Holder<Object>, Object> universe) {
+      this.universe = universe;
+    }
+
+    @Override
+    public int priority() {
+      return 2;
+    }
+
+    @Override
+    public void execute() throws Throwable {
+      final ComponentType testComponent = this.universe.resolveComponent(TestComponent.class).get();
+      for(final Holder<Object> holder : this.universe.holders().all()) {
+        holder.<TestComponent>get(testComponent).ifPresent(TestComponent::next);
+      }
+    }
+  }
+}


### PR DESCRIPTION
Provides an initial architecture to processor implementation. This does not leave the maintenance of holders and components up to the processors yet but does set up a way for that to be implemented later. Components would now be encouraged to store data instead of supply functionality. The majority of functionality should be contained within the processors.